### PR TITLE
Increase stage scanners

### DIFF
--- a/operations/deploy-stage.hcl
+++ b/operations/deploy-stage.hcl
@@ -3,22 +3,22 @@ job "sbws-stage" {
   type        = "service"
   namespace   = "ator-network"
 
+  spread {
+    attribute = "${node.unique.id}"
+    weight    = 100
+    target "c8e55509-a756-0aa7-563b-9665aa4915ab" {
+      percent = 14
+    }
+    target "c2adc610-6316-cd9d-c678-cda4b0080b52" {
+      percent = 43
+    }
+    target "4aa61f61-893a-baf4-541b-870e99ac4839" {
+      percent = 43
+    }
+  }
+
   group "sbws-stage-group" {
     count = 3
-
-    spread {
-      attribute = "${node.unique.id}"
-      weight    = 100
-      target "c8e55509-a756-0aa7-563b-9665aa4915ab" {
-        percent = 34
-      }
-      target "c2adc610-6316-cd9d-c678-cda4b0080b52" {
-        percent = 33
-      }
-      target "4aa61f61-893a-baf4-541b-870e99ac4839" {
-        percent = 33
-      }
-    }
 
     volume "sbws-stage" {
       type      = "host"
@@ -201,6 +201,460 @@ external_control_port = {{ env `NOMAD_PORT_control_port` }}
 
       service {
         name     = "sbws-destination-stage"
+        tags     = ["logging"]
+        port     = "http-port"
+        check {
+          name     = "sbws stage destination nginx alive"
+          type     = "http"
+          path     = "/"
+          interval = "10s"
+          timeout  = "10s"
+          check_restart {
+            limit = 3
+            grace = "10s"
+          }
+        }
+      }
+
+      template {
+        change_mode = "noop"
+        data        = <<EOH
+    server {
+      root /data;
+
+      autoindex on;
+      listen 0.0.0.0:{{ env `NOMAD_PORT_http_port` }};
+
+      location / {
+        try_files $uri $uri/ =404;
+      }
+
+      location ~/\.ht {
+        deny all;
+      }
+    }
+        EOH
+        destination = "local/nginx-sbws"
+      }
+    }
+  }
+
+  group "sbws-stage-group-2" {
+    count = 2
+
+    constraint {
+      operator = "distinct_hosts"
+      value    = "true"
+    }
+
+    volume "sbws-stage-group-2" {
+      type      = "host"
+      read_only = false
+      source    = "sbws-stage-group-2"
+    }
+
+    volume "sbws-destination-stage-group-2" {
+      type      = "host"
+      read_only = true
+      source    = "sbws-destination-stage-group-2"
+    }
+
+    network {
+      mode = "bridge"
+
+      port "http-port" {
+        static = 9178
+      }
+
+      port "orport" {
+        static = 19102
+      }
+
+      port "control-port" {
+        static = 19152
+        host_network = "wireguard"
+      }
+    }
+
+    task "sbws-relay-stage-task" {
+      driver = "docker"
+
+      volume_mount {
+        volume      = "sbws-stage-group-2"
+        destination = "/var/lib/anon"
+        read_only   = false
+      }
+
+      config {
+        image      = "svforte/anon-stage"
+        force_pull = true
+        volumes    = [
+          "local/anonrc:/etc/anon/anonrc"
+        ]
+      }
+
+      resources {
+        cpu    = 2048
+        memory = 2560
+      }
+
+      template {
+        change_mode = "noop"
+        data        = <<EOH
+User anond
+
+Nickname AnonSBWS
+
+DataDirectory /var/lib/anon/anon-data
+AgreeToTerms 1
+
+ControlPort {{ env `NOMAD_PORT_control_port` }}
+
+SocksPort auto
+
+ConnectionPadding auto
+SafeLogging 0
+UseEntryGuards 0
+ProtocolWarnings 1
+FetchDirInfoEarly 1
+LogTimeGranularity 1
+UseMicrodescriptors 0
+FetchDirInfoExtraEarly 1
+FetchUselessDescriptors 1
+LearnCircuitBuildTimeout 0
+
+ORPort {{ env `NOMAD_PORT_orport` }}
+        EOH
+        destination = "local/anonrc"
+      }
+
+      service {
+        name     = "sbws-relay-stage-2"
+        tags     = ["logging"]
+        port     = "control-port"
+      }
+    }
+
+    task "sbws-scanner-stage-task" {
+      driver = "docker"
+
+      env {
+        INTERVAL_MINUTES = "60"
+      }
+
+      volume_mount {
+        volume      = "sbws-stage-group-2"
+        destination = "/root/.sbws"
+        read_only   = false
+      }
+
+      config {
+        image   = "svforte/sbws-scanner:latest-stage"
+        force_pull = true
+        volumes = [
+          "local/.sbws.ini:/root/.sbws.ini:ro"
+        ]
+      }
+
+      service {
+        name     = "sbws-scanner-stage-task-2"
+        tags     = ["logging"]
+      }
+
+      resources {
+        cpu    = 1024
+        memory = 2560
+      }
+
+      template {
+        change_mode = "noop"
+        data        = <<EOH
+# Minimum configuration that needs to be customized
+[scanner]
+# ISO 3166-1 alpha-2 country code where the scanner is located.
+# Default AA, to detect it was not edited.
+country = ZZ
+# A human-readable string with chars in a-zA-Z0-9 to identify the dirauth
+# nickname that will publish the BandwidthFiles generated from this scanner.
+# Default to a non existing dirauth_nickname to detect it was not edited.
+dirauth_nickname = Anon
+
+[destinations]
+# A destination can be disabled changing `on` by `off`
+dest = on
+
+[destinations.dest]
+# the domain and path to the 1GB file.
+url = http://{{ env `NOMAD_HOST_ADDR_http-port` }}/1GiB
+# Whether to verify or not the TLS certificate. Default True.
+verify = False
+# ISO 3166-1 alpha-2 country code where the Web server destination is located.
+# Default AA, to detect it was not edited.
+# Use ZZ if the location is unknown (for instance, a CDN).
+country = ZZ
+
+[tor]
+datadir = /root/.sbws/anon-data
+external_control_ip = {{ env `NOMAD_IP_control_port` }}
+external_control_port = {{ env `NOMAD_PORT_control_port` }}
+        EOH
+        destination = "local/.sbws.ini"
+      }
+
+    }
+
+
+    task "sbws-destination-stage-task" {
+      driver = "docker"
+
+      config {
+        image   = "nginx:1.27"
+        volumes = [
+          "local/nginx-sbws:/etc/nginx/conf.d/default.conf:ro"
+        ]
+        ports = ["http-port"]
+      }
+
+      resources {
+        cpu    = 128
+        memory = 256
+      }
+
+      volume_mount {
+        volume      = "sbws-destination-stage-group-2"
+        destination = "/data"
+        read_only   = true
+      }
+
+      service {
+        name     = "sbws-destination-stage-2"
+        tags     = ["logging"]
+        port     = "http-port"
+        check {
+          name     = "sbws stage destination nginx alive"
+          type     = "http"
+          path     = "/"
+          interval = "10s"
+          timeout  = "10s"
+          check_restart {
+            limit = 3
+            grace = "10s"
+          }
+        }
+      }
+
+      template {
+        change_mode = "noop"
+        data        = <<EOH
+    server {
+      root /data;
+
+      autoindex on;
+      listen 0.0.0.0:{{ env `NOMAD_PORT_http_port` }};
+
+      location / {
+        try_files $uri $uri/ =404;
+      }
+
+      location ~/\.ht {
+        deny all;
+      }
+    }
+        EOH
+        destination = "local/nginx-sbws"
+      }
+    }
+  }
+
+  group "sbws-stage-group-3" {
+    count = 2
+
+    constraint {
+      operator = "distinct_hosts"
+      value    = "true"
+    }
+
+    volume "sbws-stage-group-3" {
+      type      = "host"
+      read_only = false
+      source    = "sbws-stage-group-3"
+    }
+
+    volume "sbws-destination-stage-group-3" {
+      type      = "host"
+      read_only = true
+      source    = "sbws-destination-stage-group-3"
+    }
+
+    network {
+      mode = "bridge"
+
+      port "http-port" {
+        static = 9179
+      }
+
+      port "orport" {
+        static = 19103
+      }
+
+      port "control-port" {
+        static = 19153
+        host_network = "wireguard"
+      }
+    }
+
+    task "sbws-relay-stage-task" {
+      driver = "docker"
+
+      volume_mount {
+        volume      = "sbws-stage-group-3"
+        destination = "/var/lib/anon"
+        read_only   = false
+      }
+
+      config {
+        image      = "svforte/anon-stage"
+        force_pull = true
+        volumes    = [
+          "local/anonrc:/etc/anon/anonrc"
+        ]
+      }
+
+      resources {
+        cpu    = 2048
+        memory = 2560
+      }
+
+      template {
+        change_mode = "noop"
+        data        = <<EOH
+User anond
+
+Nickname AnonSBWS
+
+DataDirectory /var/lib/anon/anon-data
+AgreeToTerms 1
+
+ControlPort {{ env `NOMAD_PORT_control_port` }}
+
+SocksPort auto
+
+ConnectionPadding auto
+SafeLogging 0
+UseEntryGuards 0
+ProtocolWarnings 1
+FetchDirInfoEarly 1
+LogTimeGranularity 1
+UseMicrodescriptors 0
+FetchDirInfoExtraEarly 1
+FetchUselessDescriptors 1
+LearnCircuitBuildTimeout 0
+
+ORPort {{ env `NOMAD_PORT_orport` }}
+        EOH
+        destination = "local/anonrc"
+      }
+
+      service {
+        name     = "sbws-relay-stage-3"
+        tags     = ["logging"]
+        port     = "control-port"
+      }
+    }
+
+    task "sbws-scanner-stage-task" {
+      driver = "docker"
+
+      env {
+        INTERVAL_MINUTES = "60"
+      }
+
+      volume_mount {
+        volume      = "sbws-stage-group-3"
+        destination = "/root/.sbws"
+        read_only   = false
+      }
+
+      config {
+        image   = "svforte/sbws-scanner:latest-stage"
+        force_pull = true
+        volumes = [
+          "local/.sbws.ini:/root/.sbws.ini:ro"
+        ]
+      }
+
+      service {
+        name     = "sbws-scanner-stage-task-3"
+        tags     = ["logging"]
+      }
+
+      resources {
+        cpu    = 1024
+        memory = 2560
+      }
+
+      template {
+        change_mode = "noop"
+        data        = <<EOH
+# Minimum configuration that needs to be customized
+[scanner]
+# ISO 3166-1 alpha-2 country code where the scanner is located.
+# Default AA, to detect it was not edited.
+country = ZZ
+# A human-readable string with chars in a-zA-Z0-9 to identify the dirauth
+# nickname that will publish the BandwidthFiles generated from this scanner.
+# Default to a non existing dirauth_nickname to detect it was not edited.
+dirauth_nickname = Anon
+
+[destinations]
+# A destination can be disabled changing `on` by `off`
+dest = on
+
+[destinations.dest]
+# the domain and path to the 1GB file.
+url = http://{{ env `NOMAD_HOST_ADDR_http-port` }}/1GiB
+# Whether to verify or not the TLS certificate. Default True.
+verify = False
+# ISO 3166-1 alpha-2 country code where the Web server destination is located.
+# Default AA, to detect it was not edited.
+# Use ZZ if the location is unknown (for instance, a CDN).
+country = ZZ
+
+[tor]
+datadir = /root/.sbws/anon-data
+external_control_ip = {{ env `NOMAD_IP_control_port` }}
+external_control_port = {{ env `NOMAD_PORT_control_port` }}
+        EOH
+        destination = "local/.sbws.ini"
+      }
+
+    }
+
+
+    task "sbws-destination-stage-task" {
+      driver = "docker"
+
+      config {
+        image   = "nginx:1.27"
+        volumes = [
+          "local/nginx-sbws:/etc/nginx/conf.d/default.conf:ro"
+        ]
+        ports = ["http-port"]
+      }
+
+      resources {
+        cpu    = 128
+        memory = 256
+      }
+
+      volume_mount {
+        volume      = "sbws-destination-stage-group-3"
+        destination = "/data"
+        read_only   = true
+      }
+
+      service {
+        name     = "sbws-destination-stage-3"
         tags     = ["logging"]
         port     = "http-port"
         check {


### PR DESCRIPTION
The PR increases the number of scanners running on stage to 7 but utilising the same number of nodes.


## Notes
This is similar to (PR 77) [https://github.com/ATOR-Development/ator-protocol/pull/78]  to increase the number of DAs in stage.