### PR TITLE
Switch stage images for other groups

### DIFF
--- a/operations/deploy-stage.hcl
+++ b/operations/deploy-stage.hcl
@@ -286,7 +286,7 @@ external_control_port = {{ env `NOMAD_PORT_control_port` }}
       }
 
       config {
-        image      = "svforte/anon-stage"
+        image      = "ghcr.io/ator-development/ator-protocol-stage:latest"
         force_pull = true
         volumes    = [
           "local/anonrc:/etc/anon/anonrc"
@@ -513,7 +513,7 @@ external_control_port = {{ env `NOMAD_PORT_control_port` }}
       }
 
       config {
-        image      = "svforte/anon-stage"
+        image      = "sghcr.io/ator-development/ator-protocol-stage:latest"
         force_pull = true
         volumes    = [
           "local/anonrc:/etc/anon/anonrc"


### PR DESCRIPTION
This PR extends the commit [121b9b9](https://github.com/ATOR-Development/sbws/commit/121b9b9572fad7b4a487df5be3d6891f3dd62805) to change the image stage pulls from by adding the image name to the other group configs.